### PR TITLE
Always use same key to build resultsByfiles index

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -29,7 +29,7 @@ module.exports = {
             if (resultsByfiles[result.file] === undefined) {
                 resultsByfiles[result.file] = '';
             }
-            resultsByfiles[result.fullPath] += output + ' />\n';
+            resultsByfiles[result.file] += output + ' />\n';
         });
 
         Object.keys(resultsByfiles).forEach(function (file) {


### PR DESCRIPTION
my less files are nested several directories deep which causes the "file" and "fullPath" properties on results to be different. This in turn breaks the output due to not using the same property when building the index.